### PR TITLE
Fix AWS env var name

### DIFF
--- a/backend/index_lambda/app.py
+++ b/backend/index_lambda/app.py
@@ -18,7 +18,7 @@ bedrock = boto3.client('bedrock-runtime')
 # OpenSearch クライアントのセットアップ
 def get_opensearch_client():
     auth = AWSRequestsAuth(
-        aws_access_key=os.environ['AWS_ACCESS_KEY'],
+        aws_access_key=os.environ['AWS_ACCESS_KEY_ID'],
         aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
         aws_token=os.environ['AWS_SESSION_TOKEN'],
         aws_host=OPENSEARCH_HOST,

--- a/backend/query_lambda/app.py
+++ b/backend/query_lambda/app.py
@@ -17,7 +17,7 @@ bedrock = boto3.client('bedrock-runtime')
 # OpenSearch クライアントのセットアップ
 def get_opensearch_client():
     auth = AWSRequestsAuth(
-        aws_access_key=os.environ['AWS_ACCESS_KEY'],
+        aws_access_key=os.environ['AWS_ACCESS_KEY_ID'],
         aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
         aws_token=os.environ['AWS_SESSION_TOKEN'],
         aws_host=OPENSEARCH_HOST,


### PR DESCRIPTION
## Summary
- fix wrong env var name for AWS credentials in index and query lambdas

## Testing
- `python -m py_compile backend/index_lambda/app.py backend/query_lambda/app.py frontend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6881d18819ac8322853e7c2f0bd3d5cd