### PR TITLE
Fix AWS deployment missing file and env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ env/
 .venv/
 
 # Lambda/临时依赖
-lambda_requirements.txt
 index_lambda/requirements.txt
 query_lambda/requirements.txt
 tmp/

--- a/backend/index_lambda/app.py
+++ b/backend/index_lambda/app.py
@@ -18,7 +18,7 @@ bedrock = boto3.client('bedrock-runtime')
 # OpenSearch クライアントのセットアップ
 def get_opensearch_client():
     auth = AWSRequestsAuth(
-        aws_access_key=os.environ['AWS_ACCESS_KEY'],
+        aws_access_key=os.environ['AWS_ACCESS_KEY_ID'],
         aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
         aws_token=os.environ['AWS_SESSION_TOKEN'],
         aws_host=OPENSEARCH_HOST,

--- a/backend/query_lambda/app.py
+++ b/backend/query_lambda/app.py
@@ -17,7 +17,7 @@ bedrock = boto3.client('bedrock-runtime')
 # OpenSearch クライアントのセットアップ
 def get_opensearch_client():
     auth = AWSRequestsAuth(
-        aws_access_key=os.environ['AWS_ACCESS_KEY'],
+        aws_access_key=os.environ['AWS_ACCESS_KEY_ID'],
         aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
         aws_token=os.environ['AWS_SESSION_TOKEN'],
         aws_host=OPENSEARCH_HOST,

--- a/lambda_requirements.txt
+++ b/lambda_requirements.txt
@@ -1,0 +1,2 @@
+opensearch-py
+aws-requests-auth


### PR DESCRIPTION
## Summary
- add `lambda_requirements.txt` so the deployment script succeeds
- remove ignore for this dependency file
- fix AWS env variable name in both Lambda functions

## Testing
- `python -m py_compile backend/index_lambda/app.py backend/query_lambda/app.py frontend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6881d1ed19c48322a75d94ed2b02f7bb